### PR TITLE
Fix non-working static files and templates

### DIFF
--- a/PawTravel/PawTravel/settings.py
+++ b/PawTravel/PawTravel/settings.py
@@ -67,7 +67,10 @@ ROOT_URLCONF = 'PawTravel.urls'
 TEMPLATES = [
     {
         'BACKEND': 'django.template.backends.django.DjangoTemplates',
-        'DIRS': [os.path.join(BASE_DIR, 'templates')],
+        'DIRS': [
+            os.path.join(BASE_DIR, 'templates'),
+            'pawtravel-front/public'
+        ],
         'APP_DIRS': True,
         'OPTIONS': {
             'context_processors': [
@@ -129,7 +132,10 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/4.0/howto/static-files/
 
 STATIC_URL = 'static/'
-STATICFILES_DIRS = [os.path.join(BASE_DIR, 'static')]
+STATICFILES_DIRS = [
+    os.path.join(BASE_DIR, 'static'),
+    'pawtravel-front/static'
+]
 
 # Media files
 MEDIA_ROOT = os.path.join(BASE_DIR, 'uploads')


### PR DESCRIPTION
This change depends on whether templates and static have to be moved to pawtravel-front in the first place. Please let us know.